### PR TITLE
Few build-kernel.yml improvements.

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/LineageOS/android_prebuilts_gcc_linux-x86_aarch64_aarch64-linux-android-4.9 aarch64-linux-android-4.9
           git clone --depth=1 https://github.com/LineageOS/android_prebuilts_gcc_linux-x86_arm_arm-linux-androideabi-4.9 arm-linux-androideabi-4.9
-          mkdir clang && wget https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/refs/heads/android12-release/clang-r416183b1.tar.gz && tar -C clang/ -zxvf clang-*.tar.gz
+          mkdir clang && curl https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/refs/heads/android12-release/clang-r416183b1.tar.gz -RLO && echo Unpacking... && tar -C clang/ -zxf clang-*.tar.gz
 
       - name: Pull kernel source
         run: |
@@ -43,7 +43,7 @@ jobs:
                                   CROSS_COMPILE_ARM32=$GITHUB_WORKSPACE/arm-linux-androideabi-4.9/bin/arm-linux-androideabi- "
           cd kernel-source
           make ${args} ${{ env.KERNEL_TARGET }}_defconfig
-          make -j64 ${args}
+          make -j$(nproc --all) ${args}
 
       - name: Package kernel
         run: |


### PR DESCRIPTION
* Replace `wget` with `curl` so the console doesn't get spammed with `wget` progress.
* Disable `tar` verbose output.
* Change `make` thread count to `nproc --all` instead of 64 (build time reduced from about 18 minutes to 17 minutes in my case)